### PR TITLE
Enforce maximum size on snowball

### DIFF
--- a/oprheum-game/SnowballNode.swift
+++ b/oprheum-game/SnowballNode.swift
@@ -22,6 +22,7 @@ class SnowballNode: SKNode {
     }
 
     func setSnowballMass(mass: CGFloat) {
+        if mass>1.6 {let mass = 1.8}
         self.mass = mass
         redrawSnowball()
     }


### PR DESCRIPTION
This maximum shouldn't automatically succeed without also changing the
ramp size. Closes Issue #19 
